### PR TITLE
fix: inline code background color under dark mode

### DIFF
--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -29,7 +29,7 @@
 
     code
       text-color(primary-color, primary-color-light, primary-color-dark)
-      background-color(#ceceff, #ceceff, #33333e)
+      background-color(code-background-color, code-background-color-light, code-background-color-dark)
       vertical-align: middle
       padding: 3px 0.4em
       border-radius: 3px

--- a/source/css/_variables.styl
+++ b/source/css/_variables.styl
@@ -13,6 +13,7 @@ info-font-size = 14px
 // Colors for light mode
 background-color-light = #ffffff
 primary-color-light = #333333
+code-background-color-light = #CECEFF
 primary-gray-light = #AAAAAA
 secondary-color-light = #838383
 secondary-gray-light = #666666
@@ -22,6 +23,7 @@ border-table-light = #000000
 // Colors for dark mode
 background-color-dark = #101010
 primary-color-dark = #CDCDCD
+code-background-color-dark = #33333E
 primary-gray-dark = #565656
 secondary-color-dark = #7D7D7D
 secondary-gray-dark = #9A9A9A
@@ -32,6 +34,7 @@ border-table-dark = #ffffff
 if (!hexo-config('dark_mode'))
   $background-color = background-color-light
   primary-color = primary-color-light
+  code-background-color = code-background-color-light
   primary-gray = primary-gray-light
   secondary-color = secondary-color-light
   secondary-gray = secondary-gray-light
@@ -41,6 +44,7 @@ if (!hexo-config('dark_mode'))
 else
   $background-color = background-color-dark
   primary-color = primary-color-dark
+  code-background-color = code-background-color-dark
   primary-gray = primary-gray-dark
   secondary-color = secondary-color-dark
   secondary-gray = secondary-gray-dark


### PR DESCRIPTION
之前在暗色模式的时候行内代码块的背景颜色是浅色的, 本 pr 通过类似其他颜色变量的处理方式修复了这个问题.