### PR TITLE
修复移动端页面不对称的问题

### DIFF
--- a/source/css/layout.styl
+++ b/source/css/layout.styl
@@ -141,6 +141,9 @@ del, s
   grid-template-columns: @css{minmax(75%, 800px)} auto
   grid-column-gap: 20px
 
+  @media (max-width: 768px)
+    grid-template-columns: 1fr
+
   &[data-page="category"], &[data-page="archive"]
     display: block
 
@@ -264,3 +267,4 @@ del, s
   .post-visit
     display: inline-block
     margin: 0 10px
+


### PR DESCRIPTION
移动端页面左右不对称，发现是`grid-template-columns: @css{minmax(75%, 800px)} auto`这一行导致的，尝试用@media (max-width: 768px)修复